### PR TITLE
chore: adicionar configuração de escala mínima para o serviço no worrflow de deploy

### DIFF
--- a/.github/workflows/koyeb_deploy.yml
+++ b/.github/workflows/koyeb_deploy.yml
@@ -27,3 +27,4 @@ jobs:
           service-routes: "/:5000"
           service-instance-type: free
           service-regions	: was
+          service-min-scale: 0


### PR DESCRIPTION
This pull request makes a minor update to the Koyeb deployment workflow configuration by setting the minimum service scale to zero. This allows the service to scale down to zero instances when not in use, which can help save resources and costs.

- Set `service-min-scale: 0` in `.github/workflows/koyeb_deploy.yml` to enable scaling down to zero instances.