### PR TITLE
fix: "Erro ao obter dados externos: 'NoneType' object has no attribute 'find'"

### DIFF
--- a/fundamentus/__init__.py
+++ b/fundamentus/__init__.py
@@ -1,7 +1,0 @@
-"""Package placeholder to satisfy coverage tools that expect a top-level
-package named 'fundamentus'. This file intentionally left minimal; it does
-not affect runtime imports used by the tests which import modules from the
-repo root (e.g. `main`, `api`).
-"""
-
-__all__ = []

--- a/fundamentus/api/__init__.py
+++ b/fundamentus/api/__init__.py
@@ -1,7 +1,0 @@
-"""Placeholder package for fundamentus.api to satisfy coverage tools.
-
-This file mirrors the actual `api` package used in the project root. It is
-kept minimal to avoid changing runtime behavior.
-"""
-
-__all__ = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.115.7
 uvicorn==0.21.1
 httpx==0.24.1
-beautifulsoup4==4.12.3
 aiocache==0.11.1
+lxml==6.0.1

--- a/tests/test_fundamentus.py
+++ b/tests/test_fundamentus.py
@@ -52,8 +52,62 @@ def test_get_data():
         return R()
 
     with patch("api.fundamentus.httpx.AsyncClient.get", new=AsyncMock(side_effect=fake_get)):
-        result = asyncio.run(get_data())
+        # chamamos a função original (por baixo do decorator) para evitar cache
+        result = asyncio.run(get_data.__wrapped__())
         assert "ABEV3" in result
         # checa alguns campos
         assert result["ABEV3"]["Cotacao"] == Decimal("15.00")
         assert result["ABEV3"]["P/L"] == Decimal("12.50")
+
+
+def test_ignores_short_rows():
+    # Uma linha com menos de 21 colunas deve ser ignorada (cobrir branch continue)
+    mock_html = """
+    <table id="resultado">
+        <tbody>
+            <tr>
+                <td>SHORT</td>
+                <td>1,00</td>
+                <td>2,00</td>
+            </tr>
+            <tr>
+                <td>ABEV3</td>
+                <td>15,00</td>
+                <td>12,50</td>
+                <td>1,80</td>
+                <td>2,30</td>
+                <td>0,035</td>
+                <td>0,1</td>
+                <td>0,2</td>
+                <td>0,3</td>
+                <td>0,4</td>
+                <td>0,5</td>
+                <td>0,6</td>
+                <td>0,7</td>
+                <td>0,8</td>
+                <td>0,9</td>
+                <td>1,0</td>
+                <td>1,1</td>
+                <td>1,2</td>
+                <td>1,3</td>
+                <td>1,4</td>
+                <td>1,5</td>
+            </tr>
+        </tbody>
+    </table>
+    """
+
+    async def fake_get(*args, **kwargs):
+        class R:
+            text = mock_html
+
+            def raise_for_status(self):
+                return None
+
+        return R()
+
+    with patch("api.fundamentus.httpx.AsyncClient.get", new=AsyncMock(side_effect=fake_get)):
+        result = asyncio.run(get_data())
+        # garante que a linha SHORT foi ignorada e ABEV3 processada
+        assert "SHORT" not in result
+        assert "ABEV3" in result


### PR DESCRIPTION
This pull request refactors the HTML parsing logic in `api/fundamentus.py` to use `lxml` instead of BeautifulSoup, enhances the HTTP request headers, and improves robustness by ignoring incomplete data rows. It also adds a new test to ensure that rows with insufficient columns are skipped, and removes placeholder `__init__.py` files that were only needed for code coverage tools.

**Parser and HTTP improvements:**

- Switched from BeautifulSoup to `lxml.html` for parsing HTML in `get_data`, and updated the row extraction logic to use XPath, improving performance and reliability. [[1]](diffhunk://#diff-1ba1a5eb6e59ac0643a9015ca39a15d14b5a61d9e26dc204c3e99446ef4a9475L4-R4) [[2]](diffhunk://#diff-1ba1a5eb6e59ac0643a9015ca39a15d14b5a61d9e26dc204c3e99446ef4a9475L27-R75)
- Enhanced HTTP request headers and set a timeout for `httpx.AsyncClient` to better mimic a real browser and improve request stability.
- Added logic to skip table rows with fewer than 21 columns, preventing errors from malformed or incomplete data.

**Testing improvements:**

- Added a new test (`test_ignores_short_rows`) to verify that rows with insufficient columns are ignored, increasing test coverage and robustness.

**Cleanup:**

- Removed placeholder `__init__.py` files from `fundamentus` and `fundamentus/api`, as they are no longer needed for coverage or import purposes. [[1]](diffhunk://#diff-44365d1fe868f63d403b294d491aa3d28266a943f18131724adbf4051d629ab8L1-L7) [[2]](diffhunk://#diff-65f5d8843d1cdd7856acc0f825917bfffbb7f8a37c52c45bc638bc60301e8a4eL1-L7)