### PR TITLE
build: pin mcp version to 1.27.2 to fix crash on startup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ aiocache==0.12.3
 lxml==6.0.1
 fastapi-mcp==0.4.0
 starlette==0.47.3
+mcp==1.27.2


### PR DESCRIPTION
mcp 2.0.0 was released recently and introduces breaking changes that cause fastapi-mcp 0.4.0 to crash during server initialization. Pinning to 1.27.2 restores stability.